### PR TITLE
Add flexible size property support in page builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /vendor
 /node_modules
 /public/*
+
+# Terminal Paste Image folder
+.cp-images/

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -178,5 +178,7 @@
     "Clone failed": "فشل النسخ",
     "Theme deleted successfully": "تم حذف المظهر بنجاح",
     "Theme created successfully": "تم إنشاء المظهر بنجاح",
-    "Theme updated successfully": "تم تحديث المظهر بنجاح"
+    "Theme updated successfully": "تم تحديث المظهر بنجاح",
+    "Set Default Theme": "تعيين المظهر الافتراضي",
+    "Row": "صف"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -179,5 +179,7 @@
     "Clone failed": "Clone failed",
     "Theme deleted successfully": "Theme deleted successfully",
     "Theme created successfully": "Theme created successfully",
-    "Theme updated successfully": "Theme updated successfully"
+    "Theme updated successfully": "Theme updated successfully",
+    "Set Default Theme": "Set Default Theme",
+    "Row": "Row"
 }

--- a/resources/views/dev/safe-classes-width.blade.php
+++ b/resources/views/dev/safe-classes-width.blade.php
@@ -1,0 +1,368 @@
+<div
+    class="w-[1px] w-[2px] w-[3px] w-[4px] w-[5px] w-[6px] w-[7px] w-[8px] w-[9px] w-[10px] w-[11px] w-[12px] w-[13px] w-[14px] w-[15px] w-[16px] w-[17px] w-[18px] w-[19px] w-[20px] w-[21px]">
+</div>
+<div
+    class="w-[22px] w-[23px] w-[24px] w-[25px] w-[26px] w-[27px] w-[28px] w-[29px] w-[30px] w-[31px] w-[32px] w-[33px] w-[34px] w-[35px] w-[36px] w-[37px] w-[38px] w-[39px] w-[40px] w-[41px]">
+</div>
+<div
+    class="w-[42px] w-[43px] w-[44px] w-[45px] w-[46px] w-[47px] w-[48px] w-[49px] w-[50px] w-[51px] w-[52px] w-[53px] w-[54px] w-[55px] w-[56px] w-[57px] w-[58px] w-[59px] w-[60px] w-[61px]">
+</div>
+<div
+    class="w-[62px] w-[63px] w-[64px] w-[65px] w-[66px] w-[67px] w-[68px] w-[69px] w-[70px] w-[71px] w-[72px] w-[73px] w-[74px] w-[75px] w-[76px] w-[77px] w-[78px] w-[79px] w-[80px] w-[81px]">
+</div>
+<div
+    class="w-[82px] w-[83px] w-[84px] w-[85px] w-[86px] w-[87px] w-[88px] w-[89px] w-[90px] w-[91px] w-[92px] w-[93px] w-[94px] w-[95px] w-[96px] w-[97px] w-[98px] w-[99px] w-[100px] w-[101px]">
+</div>
+<div
+    class="w-[102px] w-[103px] w-[104px] w-[105px] w-[106px] w-[107px] w-[108px] w-[109px] w-[110px] w-[111px] w-[112px] w-[113px] w-[114px] w-[115px] w-[116px] w-[117px] w-[118px] w-[119px]">
+</div>
+<div
+    class="w-[120px] w-[121px] w-[122px] w-[123px] w-[124px] w-[125px] w-[126px] w-[127px] w-[128px] w-[129px] w-[130px] w-[131px] w-[132px] w-[133px] w-[134px] w-[135px] w-[136px] w-[137px]">
+</div>
+<div
+    class="w-[138px] w-[139px] w-[140px] w-[141px] w-[142px] w-[143px] w-[144px] w-[145px] w-[146px] w-[147px] w-[148px] w-[148px] w-[149px] w-[150px]">
+</div>
+<div
+    class="w-[151px] w-[152px] w-[153px] w-[154px] w-[155px] w-[156px] w-[157px] w-[158px] w-[159px] w-[160px] w-[161px]">
+</div>
+<div
+    class="w-[162px] w-[163px] w-[164px] w-[165px] w-[166px] w-[167px] w-[168px] w-[169px] w-[170px] w-[171px] w-[172px]">
+</div>
+<div
+    class="w-[173px] w-[174px] w-[175px] w-[176px] w-[177px] w-[178px] w-[179px] w-[180px] w-[181px] w-[182px] w-[183px]">
+</div>
+<div
+    class="w-[184px] w-[185px] w-[186px] w-[187px] w-[188px] w-[189px] w-[190px] w-[191px] w-[192px] w-[193px] w-[194px]">
+</div>
+<div
+    class="w-[195px] w-[196px] w-[197px] w-[198px] w-[199px] w-[200px] w-[201px] w-[202px] w-[203px] w-[204px] w-[205px]">
+</div>
+<div
+    class="w-[206px] w-[207px] w-[208px] w-[209px] w-[210px] w-[211px] w-[212px] w-[213px] w-[214px] w-[215px] w-[216px]">
+</div>
+<div
+    class="w-[217px] w-[218px] w-[219px] w-[220px] w-[221px] w-[222px] w-[223px] w-[224px] w-[225px] w-[226px] w-[227px]">
+</div>
+<div
+    class="w-[228px] w-[229px] w-[230px] w-[231px] w-[232px] w-[233px] w-[234px] w-[235px] w-[236px] w-[237px] w-[238px]">
+</div>
+<div
+    class="w-[239px] w-[240px] w-[241px] w-[242px] w-[243px] w-[244px] w-[245px] w-[246px] w-[247px] w-[248px] w-[249px]">
+</div>
+<div
+    class="w-[250px] w-[251px] w-[252px] w-[253px] w-[254px] w-[255px] w-[256px] w-[257px] w-[258px] w-[259px] w-[260px]">
+</div>
+<div
+    class="w-[261px] w-[262px] w-[263px] w-[264px] w-[265px] w-[266px] w-[267px] w-[268px] w-[269px] w-[270px] w-[271px]">
+</div>
+<div
+    class="w-[272px] w-[273px] w-[274px] w-[275px] w-[276px] w-[277px] w-[278px] w-[279px] w-[280px] w-[281px] w-[282px]">
+</div>
+<div
+    class="w-[283px] w-[284px] w-[285px] w-[286px] w-[287px] w-[288px] w-[289px] w-[290px] w-[291px] w-[292px] w-[293px]">
+</div>
+<div
+    class="w-[294px] w-[295px] w-[296px] w-[297px] w-[298px] w-[299px] w-[300px] w-[301px] w-[302px] w-[303px] w-[304px]">
+</div>
+<div
+    class="w-[305px] w-[306px] w-[307px] w-[308px] w-[309px] w-[310px] w-[311px] w-[312px] w-[313px] w-[314px] w-[315px]">
+</div>
+<div
+    class="w-[316px] w-[317px] w-[318px] w-[319px] w-[320px] w-[321px] w-[322px] w-[323px] w-[324px] w-[325px] w-[326px]">
+</div>
+<div
+    class="w-[327px] w-[328px] w-[329px] w-[330px] w-[331px] w-[332px] w-[333px] w-[334px] w-[335px] w-[336px] w-[337px]">
+</div>
+<div
+    class="w-[338px] w-[339px] w-[340px] w-[341px] w-[342px] w-[343px] w-[344px] w-[345px] w-[346px] w-[347px] w-[348px]">
+</div>
+<div
+    class="w-[349px] w-[350px] w-[351px] w-[352px] w-[353px] w-[354px] w-[355px] w-[356px] w-[357px] w-[358px] w-[359px]">
+</div>
+<div
+    class="w-[360px] w-[361px] w-[362px] w-[363px] w-[364px] w-[365px] w-[366px] w-[367px] w-[368px] w-[369px] w-[370px]">
+</div>
+<div
+    class="w-[371px] w-[372px] w-[373px] w-[374px] w-[375px] w-[376px] w-[377px] w-[378px] w-[379px] w-[380px] w-[381px]">
+</div>
+<div
+    class="w-[382px] w-[383px] w-[384px] w-[385px] w-[386px] w-[387px] w-[388px] w-[389px] w-[390px] w-[391px] w-[392px]">
+</div>
+<div
+    class="w-[393px] w-[394px] w-[395px] w-[396px] w-[397px] w-[398px] w-[399px] w-[400px] w-[401px] w-[402px] w-[403px]">
+</div>
+<div
+    class="w-[404px] w-[405px] w-[406px] w-[407px] w-[408px] w-[409px] w-[410px] w-[411px] w-[412px] w-[413px] w-[414px]">
+</div>
+<div
+    class="w-[415px] w-[416px] w-[417px] w-[418px] w-[419px] w-[420px] w-[421px] w-[422px] w-[423px] w-[424px] w-[425px]">
+</div>
+<div
+    class="w-[426px] w-[427px] w-[428px] w-[429px] w-[430px] w-[431px] w-[432px] w-[433px] w-[434px] w-[435px] w-[436px]">
+</div>
+<div
+    class="w-[437px] w-[438px] w-[439px] w-[440px] w-[441px] w-[442px] w-[443px] w-[444px] w-[445px] w-[446px] w-[447px]">
+</div>
+<div
+    class="w-[448px] w-[449px] w-[450px] w-[451px] w-[452px] w-[453px] w-[454px] w-[455px] w-[456px] w-[457px] w-[458px]">
+</div>
+
+<div
+    class="w-[459px] w-[460px] w-[461px] w-[462px] w-[463px] w-[464px] w-[465px] w-[466px] w-[467px] w-[468px] w-[469px]">
+</div>
+<div
+    class="w-[470px] w-[471px] w-[472px] w-[473px] w-[474px] w-[475px] w-[476px] w-[477px] w-[478px] w-[479px] w-[480px]">
+</div>
+<div
+    class="w-[481px] w-[482px] w-[483px] w-[484px] w-[485px] w-[486px] w-[487px] w-[488px] w-[489px] w-[490px] w-[491px]">
+</div>
+<div
+    class="w-[492px] w-[493px] w-[494px] w-[495px] w-[496px] w-[497px] w-[498px] w-[499px] w-[500px] w-[501px] w-[502px]">
+</div>
+
+
+
+<div
+    class="@3xl:w-[1px] @3xl:w-[2px] @3xl:w-[3px] @3xl:w-[4px] @3xl:w-[5px] @3xl:w-[6px] @3xl:w-[7px] @3xl:w-[8px] @3xl:w-[9px] @3xl:w-[10px] @3xl:w-[11px] @3xl:w-[12px] @3xl:w-[13px] @3xl:w-[14px] @3xl:w-[15px] @3xl:w-[16px] @3xl:w-[17px] @3xl:w-[18px] @3xl:w-[19px] @3xl:w-[20px] @3xl:w-[21px]">
+</div>
+<div
+    class="@3xl:w-[22px] @3xl:w-[23px] @3xl:w-[24px] @3xl:w-[25px] @3xl:w-[26px] @3xl:w-[27px] @3xl:w-[28px] @3xl:w-[29px] @3xl:w-[30px] @3xl:w-[31px] @3xl:w-[32px] @3xl:w-[33px] @3xl:w-[34px] @3xl:w-[35px] @3xl:w-[36px] @3xl:w-[37px] @3xl:w-[38px] @3xl:w-[39px] @3xl:w-[40px] @3xl:w-[41px]">
+</div>
+<div
+    class="@3xl:w-[42px] @3xl:w-[43px] @3xl:w-[44px] @3xl:w-[45px] @3xl:w-[46px] @3xl:w-[47px] @3xl:w-[48px] @3xl:w-[49px] @3xl:w-[50px] @3xl:w-[51px] @3xl:w-[52px] @3xl:w-[53px] @3xl:w-[54px] @3xl:w-[55px] @3xl:w-[56px] @3xl:w-[57px] @3xl:w-[58px] @3xl:w-[59px] @3xl:w-[60px] @3xl:w-[61px]">
+</div>
+<div
+    class="@3xl:w-[62px] @3xl:w-[63px] @3xl:w-[64px] @3xl:w-[65px] @3xl:w-[66px] @3xl:w-[67px] @3xl:w-[68px] @3xl:w-[69px] @3xl:w-[70px] @3xl:w-[71px] @3xl:w-[72px] @3xl:w-[73px] @3xl:w-[74px] @3xl:w-[75px] @3xl:w-[76px] @3xl:w-[77px] @3xl:w-[78px] @3xl:w-[79px] @3xl:w-[80px] @3xl:w-[81px]">
+</div>
+<div
+    class="@3xl:w-[82px] @3xl:w-[83px] @3xl:w-[84px] @3xl:w-[85px] @3xl:w-[86px] @3xl:w-[87px] @3xl:w-[88px] @3xl:w-[89px] @3xl:w-[90px] @3xl:w-[91px] @3xl:w-[92px] @3xl:w-[93px] @3xl:w-[94px] @3xl:w-[95px] @3xl:w-[96px] @3xl:w-[97px] @3xl:w-[98px] @3xl:w-[99px] @3xl:w-[100px] @3xl:w-[101px]">
+</div>
+<div
+    class="@3xl:w-[102px] @3xl:w-[103px] @3xl:w-[104px] @3xl:w-[105px] @3xl:w-[106px] @3xl:w-[107px] @3xl:w-[108px] @3xl:w-[109px] @3xl:w-[110px] @3xl:w-[111px] @3xl:w-[112px] @3xl:w-[113px] @3xl:w-[114px] @3xl:w-[115px] @3xl:w-[116px] @3xl:w-[117px] @3xl:w-[118px] @3xl:w-[119px]">
+</div>
+<div
+    class="@3xl:w-[120px] @3xl:w-[121px] @3xl:w-[122px] @3xl:w-[123px] @3xl:w-[124px] @3xl:w-[125px] @3xl:w-[126px] @3xl:w-[127px] @3xl:w-[128px] @3xl:w-[129px] @3xl:w-[130px] @3xl:w-[131px] @3xl:w-[132px] @3xl:w-[133px] @3xl:w-[134px] @3xl:w-[135px] @3xl:w-[136px] @3xl:w-[137px]">
+</div>
+<div
+    class="@3xl:w-[138px] @3xl:w-[139px] @3xl:w-[140px] @3xl:w-[141px] @3xl:w-[142px] @3xl:w-[143px] @3xl:w-[144px] @3xl:w-[145px] @3xl:w-[146px] @3xl:w-[147px] @3xl:w-[148px] @3xl:w-[148px] @3xl:w-[149px] @3xl:w-[150px]">
+</div>
+<div
+    class="@3xl:w-[151px] @3xl:w-[152px] @3xl:w-[153px] @3xl:w-[154px] @3xl:w-[155px] @3xl:w-[156px] @3xl:w-[157px] @3xl:w-[158px] @3xl:w-[159px] @3xl:w-[160px] @3xl:w-[161px]">
+</div>
+<div
+    class="@3xl:w-[162px] @3xl:w-[163px] @3xl:w-[164px] @3xl:w-[165px] @3xl:w-[166px] @3xl:w-[167px] @3xl:w-[168px] @3xl:w-[169px] @3xl:w-[170px] @3xl:w-[171px] @3xl:w-[172px]">
+</div>
+<div
+    class="@3xl:w-[173px] @3xl:w-[174px] @3xl:w-[175px] @3xl:w-[176px] @3xl:w-[177px] @3xl:w-[178px] @3xl:w-[179px] @3xl:w-[180px] @3xl:w-[181px] @3xl:w-[182px] @3xl:w-[183px]">
+</div>
+<div
+    class="@3xl:w-[184px] @3xl:w-[185px] @3xl:w-[186px] @3xl:w-[187px] @3xl:w-[188px] @3xl:w-[189px] @3xl:w-[190px] @3xl:w-[191px] @3xl:w-[192px] @3xl:w-[193px] @3xl:w-[194px]">
+</div>
+<div
+    class="@3xl:w-[195px] @3xl:w-[196px] @3xl:w-[197px] @3xl:w-[198px] @3xl:w-[199px] @3xl:w-[200px] @3xl:w-[201px] @3xl:w-[202px] @3xl:w-[203px] @3xl:w-[204px] @3xl:w-[205px]">
+</div>
+<div
+    class="@3xl:w-[206px] @3xl:w-[207px] @3xl:w-[208px] @3xl:w-[209px] @3xl:w-[210px] @3xl:w-[211px] @3xl:w-[212px] @3xl:w-[213px] @3xl:w-[214px] @3xl:w-[215px] @3xl:w-[216px]">
+</div>
+<div
+    class="@3xl:w-[217px] @3xl:w-[218px] @3xl:w-[219px] @3xl:w-[220px] @3xl:w-[221px] @3xl:w-[222px] @3xl:w-[223px] @3xl:w-[224px] @3xl:w-[225px] @3xl:w-[226px] @3xl:w-[227px]">
+</div>
+<div
+    class="@3xl:w-[228px] @3xl:w-[229px] @3xl:w-[230px] @3xl:w-[231px] @3xl:w-[232px] @3xl:w-[233px] @3xl:w-[234px] @3xl:w-[235px] @3xl:w-[236px] @3xl:w-[237px] @3xl:w-[238px]">
+</div>
+<div
+    class="@3xl:w-[239px] @3xl:w-[240px] @3xl:w-[241px] @3xl:w-[242px] @3xl:w-[243px] @3xl:w-[244px] @3xl:w-[245px] @3xl:w-[246px] @3xl:w-[247px] @3xl:w-[248px] @3xl:w-[249px]">
+</div>
+<div
+    class="@3xl:w-[250px] @3xl:w-[251px] @3xl:w-[252px] @3xl:w-[253px] @3xl:w-[254px] @3xl:w-[255px] @3xl:w-[256px] @3xl:w-[257px] @3xl:w-[258px] @3xl:w-[259px] @3xl:w-[260px]">
+</div>
+<div
+    class="@3xl:w-[261px] @3xl:w-[262px] @3xl:w-[263px] @3xl:w-[264px] @3xl:w-[265px] @3xl:w-[266px] @3xl:w-[267px] @3xl:w-[268px] @3xl:w-[269px] @3xl:w-[270px] @3xl:w-[271px]">
+</div>
+<div
+    class="@3xl:w-[272px] @3xl:w-[273px] @3xl:w-[274px] @3xl:w-[275px] @3xl:w-[276px] @3xl:w-[277px] @3xl:w-[278px] @3xl:w-[279px] @3xl:w-[280px] @3xl:w-[281px] @3xl:w-[282px]">
+</div>
+<div
+    class="@3xl:w-[283px] @3xl:w-[284px] @3xl:w-[285px] @3xl:w-[286px] @3xl:w-[287px] @3xl:w-[288px] @3xl:w-[289px] @3xl:w-[290px] @3xl:w-[291px] @3xl:w-[292px] @3xl:w-[293px]">
+</div>
+<div
+    class="@3xl:w-[294px] @3xl:w-[295px] @3xl:w-[296px] @3xl:w-[297px] @3xl:w-[298px] @3xl:w-[299px] @3xl:w-[300px] @3xl:w-[301px] @3xl:w-[302px] @3xl:w-[303px] @3xl:w-[304px]">
+</div>
+<div
+    class="@3xl:w-[305px] @3xl:w-[306px] @3xl:w-[307px] @3xl:w-[308px] @3xl:w-[309px] @3xl:w-[310px] @3xl:w-[311px] @3xl:w-[312px] @3xl:w-[313px] @3xl:w-[314px] @3xl:w-[315px]">
+</div>
+<div
+    class="@3xl:w-[316px] @3xl:w-[317px] @3xl:w-[318px] @3xl:w-[319px] @3xl:w-[320px] @3xl:w-[321px] @3xl:w-[322px] @3xl:w-[323px] @3xl:w-[324px] @3xl:w-[325px] @3xl:w-[326px]">
+</div>
+<div
+    class="@3xl:w-[327px] @3xl:w-[328px] @3xl:w-[329px] @3xl:w-[330px] @3xl:w-[331px] @3xl:w-[332px] @3xl:w-[333px] @3xl:w-[334px] @3xl:w-[335px] @3xl:w-[336px] @3xl:w-[337px]">
+</div>
+<div
+    class="@3xl:w-[338px] @3xl:w-[339px] @3xl:w-[340px] @3xl:w-[341px] @3xl:w-[342px] @3xl:w-[343px] @3xl:w-[344px] @3xl:w-[345px] @3xl:w-[346px] @3xl:w-[347px] @3xl:w-[348px]">
+</div>
+<div
+    class="@3xl:w-[349px] @3xl:w-[350px] @3xl:w-[351px] @3xl:w-[352px] @3xl:w-[353px] @3xl:w-[354px] @3xl:w-[355px] @3xl:w-[356px] @3xl:w-[357px] @3xl:w-[358px] @3xl:w-[359px]">
+</div>
+<div
+    class="@3xl:w-[360px] @3xl:w-[361px] @3xl:w-[362px] @3xl:w-[363px] @3xl:w-[364px] @3xl:w-[365px] @3xl:w-[366px] @3xl:w-[367px] @3xl:w-[368px] @3xl:w-[369px] @3xl:w-[370px]">
+</div>
+<div
+    class="@3xl:w-[371px] @3xl:w-[372px] @3xl:w-[373px] @3xl:w-[374px] @3xl:w-[375px] @3xl:w-[376px] @3xl:w-[377px] @3xl:w-[378px] @3xl:w-[379px] @3xl:w-[380px] @3xl:w-[381px]">
+</div>
+<div
+    class="@3xl:w-[382px] @3xl:w-[383px] @3xl:w-[384px] @3xl:w-[385px] @3xl:w-[386px] @3xl:w-[387px] @3xl:w-[388px] @3xl:w-[389px] @3xl:w-[390px] @3xl:w-[391px] @3xl:w-[392px]">
+</div>
+<div
+    class="@3xl:w-[393px] @3xl:w-[394px] @3xl:w-[395px] @3xl:w-[396px] @3xl:w-[397px] @3xl:w-[398px] @3xl:w-[399px] @3xl:w-[400px] @3xl:w-[401px] @3xl:w-[402px] @3xl:w-[403px]">
+</div>
+<div
+    class="@3xl:w-[404px] @3xl:w-[405px] @3xl:w-[406px] @3xl:w-[407px] @3xl:w-[408px] @3xl:w-[409px] @3xl:w-[410px] @3xl:w-[411px] @3xl:w-[412px] @3xl:w-[413px] @3xl:w-[414px]">
+</div>
+<div
+    class="@3xl:w-[415px] @3xl:w-[416px] @3xl:w-[417px] @3xl:w-[418px] @3xl:w-[419px] @3xl:w-[420px] @3xl:w-[421px] @3xl:w-[422px] @3xl:w-[423px] @3xl:w-[424px] @3xl:w-[425px]">
+</div>
+<div
+    class="@3xl:w-[426px] @3xl:w-[427px] @3xl:w-[428px] @3xl:w-[429px] @3xl:w-[430px] @3xl:w-[431px] @3xl:w-[432px] @3xl:w-[433px] @3xl:w-[434px] @3xl:w-[435px] @3xl:w-[436px]">
+</div>
+<div
+    class="@3xl:w-[437px] @3xl:w-[438px] @3xl:w-[439px] @3xl:w-[440px] @3xl:w-[441px] @3xl:w-[442px] @3xl:w-[443px] @3xl:w-[444px] @3xl:w-[445px] @3xl:w-[446px] @3xl:w-[447px]">
+</div>
+<div
+    class="@3xl:w-[448px] @3xl:w-[449px] @3xl:w-[450px] @3xl:w-[451px] @3xl:w-[452px] @3xl:w-[453px] @3xl:w-[454px] @3xl:w-[455px] @3xl:w-[456px] @3xl:w-[457px] @3xl:w-[458px]">
+</div>
+
+<div
+    class="@5xl:w-[459px] @5xl:w-[460px] @5xl:w-[461px] @5xl:w-[462px] @5xl:w-[463px] @5xl:w-[464px] @5xl:w-[465px] @5xl:w-[466px] @5xl:w-[467px] @5xl:w-[468px] @5xl:w-[469px]">
+</div>
+<div
+    class="@5xl:w-[470px] @5xl:w-[471px] @5xl:w-[472px] @5xl:w-[473px] @5xl:w-[474px] @5xl:w-[475px] @5xl:w-[476px] @5xl:w-[477px] @5xl:w-[478px] @5xl:w-[479px] @5xl:w-[480px]">
+</div>
+<div
+    class="@5xl:w-[481px] @5xl:w-[482px] @5xl:w-[483px] @5xl:w-[484px] @5xl:w-[485px] @5xl:w-[486px] @5xl:w-[487px] @5xl:w-[488px] @5xl:w-[489px] @5xl:w-[490px] @5xl:w-[491px]">
+</div>
+<div
+    class="@5xl:w-[492px] @5xl:w-[493px] @5xl:w-[494px] @5xl:w-[495px] @5xl:w-[496px] @5xl:w-[497px] @5xl:w-[498px] @5xl:w-[499px] @5xl:w-[500px] @5xl:w-[501px] @5xl:w-[502px]">
+</div>
+
+
+<div
+    class="@5xl:w-[1px] @5xl:w-[2px] @5xl:w-[3px] @5xl:w-[4px] @5xl:w-[5px] @5xl:w-[6px] @5xl:w-[7px] @5xl:w-[8px] @5xl:w-[9px] @5xl:w-[10px] @5xl:w-[11px] @5xl:w-[12px] @5xl:w-[13px] @5xl:w-[14px] @5xl:w-[15px] @5xl:w-[16px] @5xl:w-[17px] @5xl:w-[18px] @5xl:w-[19px] @5xl:w-[20px] @5xl:w-[21px]">
+</div>
+<div
+    class="@5xl:w-[22px] @5xl:w-[23px] @5xl:w-[24px] @5xl:w-[25px] @5xl:w-[26px] @5xl:w-[27px] @5xl:w-[28px] @5xl:w-[29px] @5xl:w-[30px] @5xl:w-[31px] @5xl:w-[32px] @5xl:w-[33px] @5xl:w-[34px] @5xl:w-[35px] @5xl:w-[36px] @5xl:w-[37px] @5xl:w-[38px] @5xl:w-[39px] @5xl:w-[40px] @5xl:w-[41px]">
+</div>
+<div
+    class="@5xl:w-[42px] @5xl:w-[43px] @5xl:w-[44px] @5xl:w-[45px] @5xl:w-[46px] @5xl:w-[47px] @5xl:w-[48px] @5xl:w-[49px] @5xl:w-[50px] @5xl:w-[51px] @5xl:w-[52px] @5xl:w-[53px] @5xl:w-[54px] @5xl:w-[55px] @5xl:w-[56px] @5xl:w-[57px] @5xl:w-[58px] @5xl:w-[59px] @5xl:w-[60px] @5xl:w-[61px]">
+</div>
+<div
+    class="@5xl:w-[62px] @5xl:w-[63px] @5xl:w-[64px] @5xl:w-[65px] @5xl:w-[66px] @5xl:w-[67px] @5xl:w-[68px] @5xl:w-[69px] @5xl:w-[70px] @5xl:w-[71px] @5xl:w-[72px] @5xl:w-[73px] @5xl:w-[74px] @5xl:w-[75px] @5xl:w-[76px] @5xl:w-[77px] @5xl:w-[78px] @5xl:w-[79px] @5xl:w-[80px] @5xl:w-[81px]">
+</div>
+<div
+    class="@5xl:w-[82px] @5xl:w-[83px] @5xl:w-[84px] @5xl:w-[85px] @5xl:w-[86px] @5xl:w-[87px] @5xl:w-[88px] @5xl:w-[89px] @5xl:w-[90px] @5xl:w-[91px] @5xl:w-[92px] @5xl:w-[93px] @5xl:w-[94px] @5xl:w-[95px] @5xl:w-[96px] @5xl:w-[97px] @5xl:w-[98px] @5xl:w-[99px] @5xl:w-[100px] @5xl:w-[101px]">
+</div>
+<div
+    class="@5xl:w-[102px] @5xl:w-[103px] @5xl:w-[104px] @5xl:w-[105px] @5xl:w-[106px] @5xl:w-[107px] @5xl:w-[108px] @5xl:w-[109px] @5xl:w-[110px] @5xl:w-[111px] @5xl:w-[112px] @5xl:w-[113px] @5xl:w-[114px] @5xl:w-[115px] @5xl:w-[116px] @5xl:w-[117px] @5xl:w-[118px] @5xl:w-[119px]">
+</div>
+<div
+    class="@5xl:w-[120px] @5xl:w-[121px] @5xl:w-[122px] @5xl:w-[123px] @5xl:w-[124px] @5xl:w-[125px] @5xl:w-[126px] @5xl:w-[127px] @5xl:w-[128px] @5xl:w-[129px] @5xl:w-[130px] @5xl:w-[131px] @5xl:w-[132px] @5xl:w-[133px] @5xl:w-[134px] @5xl:w-[135px] @5xl:w-[136px] @5xl:w-[137px]">
+</div>
+<div
+    class="@5xl:w-[138px] @5xl:w-[139px] @5xl:w-[140px] @5xl:w-[141px] @5xl:w-[142px] @5xl:w-[143px] @5xl:w-[144px] @5xl:w-[145px] @5xl:w-[146px] @5xl:w-[147px] @5xl:w-[148px] @5xl:w-[148px] @5xl:w-[149px] @5xl:w-[150px]">
+</div>
+<div
+    class="@5xl:w-[151px] @5xl:w-[152px] @5xl:w-[153px] @5xl:w-[154px] @5xl:w-[155px] @5xl:w-[156px] @5xl:w-[157px] @5xl:w-[158px] @5xl:w-[159px] @5xl:w-[160px] @5xl:w-[161px]">
+</div>
+<div
+    class="@5xl:w-[162px] @5xl:w-[163px] @5xl:w-[164px] @5xl:w-[165px] @5xl:w-[166px] @5xl:w-[167px] @5xl:w-[168px] @5xl:w-[169px] @5xl:w-[170px] @5xl:w-[171px] @5xl:w-[172px]">
+</div>
+<div
+    class="@5xl:w-[173px] @5xl:w-[174px] @5xl:w-[175px] @5xl:w-[176px] @5xl:w-[177px] @5xl:w-[178px] @5xl:w-[179px] @5xl:w-[180px] @5xl:w-[181px] @5xl:w-[182px] @5xl:w-[183px]">
+</div>
+<div
+    class="@5xl:w-[184px] @5xl:w-[185px] @5xl:w-[186px] @5xl:w-[187px] @5xl:w-[188px] @5xl:w-[189px] @5xl:w-[190px] @5xl:w-[191px] @5xl:w-[192px] @5xl:w-[193px] @5xl:w-[194px]">
+</div>
+<div
+    class="@5xl:w-[195px] @5xl:w-[196px] @5xl:w-[197px] @5xl:w-[198px] @5xl:w-[199px] @5xl:w-[200px] @5xl:w-[201px] @5xl:w-[202px] @5xl:w-[203px] @5xl:w-[204px] @5xl:w-[205px]">
+</div>
+<div
+    class="@5xl:w-[206px] @5xl:w-[207px] @5xl:w-[208px] @5xl:w-[209px] @5xl:w-[210px] @5xl:w-[211px] @5xl:w-[212px] @5xl:w-[213px] @5xl:w-[214px] @5xl:w-[215px] @5xl:w-[216px]">
+</div>
+<div
+    class="@5xl:w-[217px] @5xl:w-[218px] @5xl:w-[219px] @5xl:w-[220px] @5xl:w-[221px] @5xl:w-[222px] @5xl:w-[223px] @5xl:w-[224px] @5xl:w-[225px] @5xl:w-[226px] @5xl:w-[227px]">
+</div>
+<div
+    class="@5xl:w-[228px] @5xl:w-[229px] @5xl:w-[230px] @5xl:w-[231px] @5xl:w-[232px] @5xl:w-[233px] @5xl:w-[234px] @5xl:w-[235px] @5xl:w-[236px] @5xl:w-[237px] @5xl:w-[238px]">
+</div>
+<div
+    class="@5xl:w-[239px] @5xl:w-[240px] @5xl:w-[241px] @5xl:w-[242px] @5xl:w-[243px] @5xl:w-[244px] @5xl:w-[245px] @5xl:w-[246px] @5xl:w-[247px] @5xl:w-[248px] @5xl:w-[249px]">
+</div>
+<div
+    class="@5xl:w-[250px] @5xl:w-[251px] @5xl:w-[252px] @5xl:w-[253px] @5xl:w-[254px] @5xl:w-[255px] @5xl:w-[256px] @5xl:w-[257px] @5xl:w-[258px] @5xl:w-[259px] @5xl:w-[260px]">
+</div>
+<div
+    class="@5xl:w-[261px] @5xl:w-[262px] @5xl:w-[263px] @5xl:w-[264px] @5xl:w-[265px] @5xl:w-[266px] @5xl:w-[267px] @5xl:w-[268px] @5xl:w-[269px] @5xl:w-[270px] @5xl:w-[271px]">
+</div>
+<div
+    class="@5xl:w-[272px] @5xl:w-[273px] @5xl:w-[274px] @5xl:w-[275px] @5xl:w-[276px] @5xl:w-[277px] @5xl:w-[278px] @5xl:w-[279px] @5xl:w-[280px] @5xl:w-[281px] @5xl:w-[282px]">
+</div>
+<div
+    class="@5xl:w-[283px] @5xl:w-[284px] @5xl:w-[285px] @5xl:w-[286px] @5xl:w-[287px] @5xl:w-[288px] @5xl:w-[289px] @5xl:w-[290px] @5xl:w-[291px] @5xl:w-[292px] @5xl:w-[293px]">
+</div>
+<div
+    class="@5xl:w-[294px] @5xl:w-[295px] @5xl:w-[296px] @5xl:w-[297px] @5xl:w-[298px] @5xl:w-[299px] @5xl:w-[300px] @5xl:w-[301px] @5xl:w-[302px] @5xl:w-[303px] @5xl:w-[304px]">
+</div>
+<div
+    class="@5xl:w-[305px] @5xl:w-[306px] @5xl:w-[307px] @5xl:w-[308px] @5xl:w-[309px] @5xl:w-[310px] @5xl:w-[311px] @5xl:w-[312px] @5xl:w-[313px] @5xl:w-[314px] @5xl:w-[315px]">
+</div>
+<div
+    class="@5xl:w-[316px] @5xl:w-[317px] @5xl:w-[318px] @5xl:w-[319px] @5xl:w-[320px] @5xl:w-[321px] @5xl:w-[322px] @5xl:w-[323px] @5xl:w-[324px] @5xl:w-[325px] @5xl:w-[326px]">
+</div>
+<div
+    class="@5xl:w-[327px] @5xl:w-[328px] @5xl:w-[329px] @5xl:w-[330px] @5xl:w-[331px] @5xl:w-[332px] @5xl:w-[333px] @5xl:w-[334px] @5xl:w-[335px] @5xl:w-[336px] @5xl:w-[337px]">
+</div>
+<div
+    class="@5xl:w-[338px] @5xl:w-[339px] @5xl:w-[340px] @5xl:w-[341px] @5xl:w-[342px] @5xl:w-[343px] @5xl:w-[344px] @5xl:w-[345px] @5xl:w-[346px] @5xl:w-[347px] @5xl:w-[348px]">
+</div>
+<div
+    class="@5xl:w-[349px] @5xl:w-[350px] @5xl:w-[351px] @5xl:w-[352px] @5xl:w-[353px] @5xl:w-[354px] @5xl:w-[355px] @5xl:w-[356px] @5xl:w-[357px] @5xl:w-[358px] @5xl:w-[359px]">
+</div>
+<div
+    class="@5xl:w-[360px] @5xl:w-[361px] @5xl:w-[362px] @5xl:w-[363px] @5xl:w-[364px] @5xl:w-[365px] @5xl:w-[366px] @5xl:w-[367px] @5xl:w-[368px] @5xl:w-[369px] @5xl:w-[370px]">
+</div>
+<div
+    class="@5xl:w-[371px] @5xl:w-[372px] @5xl:w-[373px] @5xl:w-[374px] @5xl:w-[375px] @5xl:w-[376px] @5xl:w-[377px] @5xl:w-[378px] @5xl:w-[379px] @5xl:w-[380px] @5xl:w-[381px]">
+</div>
+<div
+    class="@5xl:w-[382px] @5xl:w-[383px] @5xl:w-[384px] @5xl:w-[385px] @5xl:w-[386px] @5xl:w-[387px] @5xl:w-[388px] @5xl:w-[389px] @5xl:w-[390px] @5xl:w-[391px] @5xl:w-[392px]">
+</div>
+<div
+    class="@5xl:w-[393px] @5xl:w-[394px] @5xl:w-[395px] @5xl:w-[396px] @5xl:w-[397px] @5xl:w-[398px] @5xl:w-[399px] @5xl:w-[400px] @5xl:w-[401px] @5xl:w-[402px] @5xl:w-[403px]">
+</div>
+<div
+    class="@5xl:w-[404px] @5xl:w-[405px] @5xl:w-[406px] @5xl:w-[407px] @5xl:w-[408px] @5xl:w-[409px] @5xl:w-[410px] @5xl:w-[411px] @5xl:w-[412px] @5xl:w-[413px] @5xl:w-[414px]">
+</div>
+<div
+    class="@5xl:w-[415px] @5xl:w-[416px] @5xl:w-[417px] @5xl:w-[418px] @5xl:w-[419px] @5xl:w-[420px] @5xl:w-[421px] @5xl:w-[422px] @5xl:w-[423px] @5xl:w-[424px] @5xl:w-[425px]">
+</div>
+<div
+    class="@5xl:w-[426px] @5xl:w-[427px] @5xl:w-[428px] @5xl:w-[429px] @5xl:w-[430px] @5xl:w-[431px] @5xl:w-[432px] @5xl:w-[433px] @5xl:w-[434px] @5xl:w-[435px] @5xl:w-[436px]">
+</div>
+<div
+    class="@5xl:w-[437px] @5xl:w-[438px] @5xl:w-[439px] @5xl:w-[440px] @5xl:w-[441px] @5xl:w-[442px] @5xl:w-[443px] @5xl:w-[444px] @5xl:w-[445px] @5xl:w-[446px] @5xl:w-[447px]">
+</div>
+<div
+    class="@5xl:w-[448px] @5xl:w-[449px] @5xl:w-[450px] @5xl:w-[451px] @5xl:w-[452px] @5xl:w-[453px] @5xl:w-[454px] @5xl:w-[455px] @5xl:w-[456px] @5xl:w-[457px] @5xl:w-[458px]">
+</div>
+
+<div
+    class="@5xl:w-[459px] @5xl:w-[460px] @5xl:w-[461px] @5xl:w-[462px] @5xl:w-[463px] @5xl:w-[464px] @5xl:w-[465px] @5xl:w-[466px] @5xl:w-[467px] @5xl:w-[468px] @5xl:w-[469px]">
+</div>
+<div
+    class="@5xl:w-[470px] @5xl:w-[471px] @5xl:w-[472px] @5xl:w-[473px] @5xl:w-[474px] @5xl:w-[475px] @5xl:w-[476px] @5xl:w-[477px] @5xl:w-[478px] @5xl:w-[479px] @5xl:w-[480px]">
+</div>
+<div
+    class="@5xl:w-[481px] @5xl:w-[482px] @5xl:w-[483px] @5xl:w-[484px] @5xl:w-[485px] @5xl:w-[486px] @5xl:w-[487px] @5xl:w-[488px] @5xl:w-[489px] @5xl:w-[490px] @5xl:w-[491px]">
+</div>
+<div
+    class="@5xl:w-[492px] @5xl:w-[493px] @5xl:w-[494px] @5xl:w-[495px] @5xl:w-[496px] @5xl:w-[497px] @5xl:w-[498px] @5xl:w-[499px] @5xl:w-[500px] @5xl:w-[501px] @5xl:w-[502px]">
+</div>

--- a/resources/views/livewire/builder/block-properties.blade.php
+++ b/resources/views/livewire/builder/block-properties.blade.php
@@ -68,6 +68,9 @@
                                 @elseif($property['type'] === 'richtext')
                                     <livewire:block-properties.richtext-property :property-name="$property['name']" :property-label="$property['label']"
                                         :current-value="$properties[$property['name']] ?? ''" :row-id="$rowId" :block-id="$blockId" :key="'richtext-property-' . $key" />
+                                @elseif($property['type'] === 'flexible-size')
+                                    <livewire:block-properties.flexible-size-property :property="$property" :value="$properties[$property['name']] ?? ''"
+                                        :row-id="$rowId" :block-id="$blockId" :key="'flexible-size-property-' . $key" />
                                 @else
                                     <div>
                                         <label

--- a/resources/views/livewire/builder/block-properties/flexible-size-property.blade.php
+++ b/resources/views/livewire/builder/block-properties/flexible-size-property.blade.php
@@ -1,0 +1,35 @@
+<div class="form-control w-full">
+    <label class="label">
+        <span class="label-text">{{ $property['label'] }}</span>
+    </label>
+
+    <!-- Mode Toggle -->
+    <div class="tabs tabs-boxed mb-3">
+        <button wire:click="$set('mode', 'class')" class="tab {{ $mode === 'class' ? 'tab-active' : '' }}" type="button">
+            <x-heroicon-o-squares-2x2 class="w-4 h-4 me-2" />
+            Classes
+        </button>
+        <button wire:click="$set('mode', 'custom')" class="tab {{ $mode === 'custom' ? 'tab-active' : '' }}"
+            type="button">
+            <x-heroicon-o-pencil class="w-4 h-4 me-2" />
+            Custom
+        </button>
+    </div>
+
+    @if ($mode === 'class')
+        <!-- Class Selection -->
+        <select wire:model.live="selectedClass" class="select select-bordered w-full">
+            <option value="">Select {{ strtolower($property['label']) }}</option>
+            @foreach ($property['classes'] as $class => $label)
+                <option value="{{ $class }}">{{ $label }}</option>
+            @endforeach
+        </select>
+    @else
+        <!-- Custom Value Input -->
+        <div class="flex items-center gap-2">
+            <input type="number" wire:model.live="customValue" class="input input-bordered input-sm flex-1"
+                placeholder="100" min="0" step="1">
+            <span class="text-sm font-mono text-base-content/70">{{ $property['unit'] }}</span>
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/builder/builder-block.blade.php
+++ b/resources/views/livewire/builder/builder-block.blade.php
@@ -2,7 +2,8 @@
     class="{{ $cssClasses }} border transition-all duration-300 ease-in-out" style="{{ $inlineStyles }}"
     :class="selected ? 'border-blue-500' : 'border-gray-300'"
     x-on:block-selected.window="selected = $event.detail.blockId == '{{ $blockId }}'"
-    x-on:row-selected.window="selected = false" @contextmenu.prevent="
+    x-on:row-selected.window="selected = false"
+    @if (!$isRowBlock) @contextmenu.prevent="
         Livewire.dispatch('show-block-context-menu', {
             blockId: '{{ $blockId }}',
             x: $event.clientX,
@@ -17,49 +18,62 @@
         } else {
             showContextMenu = false;
         }
-    " @click.outside="showContextMenu = false">
+    " @click.outside="showContextMenu = false" > @endif
     <div class="relative">
+    @if ($isRowBlock)
+        <!-- For RowBlocks, add minimal click handling that doesn't interfere with inner blocks -->
+        <div class="builder-block relative" @click.self="$wire.blockSelected()">
+            @if (!$classExists)
+                <div class="text-red-500">{{ __('Unknown block') }}: {{ $blockAlias }}</div>
+            @else
+                @livewire($blockAlias, $componentProperties, key($blockId . '-' . md5(json_encode($componentProperties))))
+            @endif
+        </div>
+    @else
+        <!-- For regular blocks, use the normal click handling -->
         <div class="cursor-pointer" wire:click="blockSelected()">
             <div class="builder-block relative">
                 @if (!$classExists)
-                <div class="text-red-500">{{ __('Unknown block') }}: {{ $blockAlias }}</div>
+                    <div class="text-red-500">{{ __('Unknown block') }}: {{ $blockAlias }}</div>
                 @else
-                @livewire($blockAlias, $properties, key($blockId . '-' . md5(json_encode($properties))))
+                    @livewire($blockAlias, $componentProperties, key($blockId . '-' . md5(json_encode($componentProperties))))
                 @endif
                 <div class="absolute inset-0 z-50" style="pointer-events: all;"></div>
             </div>
         </div>
-        <!-- Context Menu UI -->
-        <div x-show="showContextMenu" x-transition:enter="transition ease-out duration-100"
-            x-transition:enter-start="opacity-0 scale-95" x-transition:enter-end="opacity-100 scale-100"
-            x-transition:leave="transition ease-in duration-75" x-transition:leave-start="opacity-100 scale-100"
-            x-transition:leave-end="opacity-0 scale-95" :style="`position: fixed; left: ${x}px; top: ${y}px;`"
-            class="context-menu bg-white border border-gray-200 rounded-lg shadow-lg py-2 w-[250px] z-52">
+    @endif
+    <!-- Context Menu UI -->
+    <div x-show="showContextMenu" x-transition:enter="transition ease-out duration-100"
+        x-transition:enter-start="opacity-0 scale-95" x-transition:enter-end="opacity-100 scale-100"
+        x-transition:leave="transition ease-in duration-75" x-transition:leave-start="opacity-100 scale-100"
+        x-transition:leave-end="opacity-0 scale-95" :style="`position: fixed; left: ${x}px; top: ${y}px;`"
+        class="context-menu bg-white border border-gray-200 rounded-lg shadow-lg py-2 w-[250px] z-52">
 
-            <div
-                class="px-4 py-1 text-xs font-semibold text-gray-500 uppercase tracking-wider border-b border-gray-100 dark:border-gray-700 mb-1">
-                {{ __('Block Actions') }}
+        <div
+            class="px-4 py-1 text-xs font-semibold text-gray-500 uppercase tracking-wider border-b border-gray-100 dark:border-gray-700 mb-1">
+            {{ __('Block Actions') }}
+        </div>
+
+        <button wire:click="blockSelected(); showContextMenu = false;"
+            class="flex items-center w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 border-b border-gray-50">
+            <x-heroicon-o-cursor-arrow-rays class="w-4 h-4 ms-0 me-3 text-gray-500" />
+            <span>{{ __('Select') }}</span>
+        </button>
+        <button wire:click="copyBlock(); showContextMenu = false;"
+            class="flex items-center w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 border-b border-gray-50">
+            <x-heroicon-o-clipboard-document class="w-4 h-4 ms-0 me-3 text-gray-500" />
+            <span>{{ __('Copy') }}</span>
+        </button>
+
+        <!-- Paste Block (combined before/after options) -->
+        <div class="flex items-center w-full px-4 py-2 text-sm text-gray-700 border-b border-gray-50">
+            <div class="flex items-center flex-1">
+                <x-heroicon-o-clipboard-document-check class="w-4 h-4 ms-0 me-3 text-gray-500" />
+                <span>{{ __('Paste') }}</span>
             </div>
-
-            <button wire:click="blockSelected(); showContextMenu = false;"
-                class="flex items-center w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 border-b border-gray-50">
-                <x-heroicon-o-cursor-arrow-rays class="w-4 h-4 ms-0 me-3 text-gray-500" />
-                <span>{{ __('Select') }}</span>
-            </button>
-            <button wire:click="copyBlock(); showContextMenu = false;"
-                class="flex items-center w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 border-b border-gray-50">
-                <x-heroicon-o-clipboard-document class="w-4 h-4 ms-0 me-3 text-gray-500" />
-                <span>{{ __('Copy') }}</span>
-            </button>
-
-            <!-- Paste Block (combined before/after options) -->
-            <div class="flex items-center w-full px-4 py-2 text-sm text-gray-700 border-b border-gray-50">
-                <div class="flex items-center flex-1">
-                    <x-heroicon-o-clipboard-document-check class="w-4 h-4 ms-0 me-3 text-gray-500" />
-                    <span>{{ __('Paste') }}</span>
-                </div>
-                <div class="flex space-x-2 rtl:space-x-reverse">
-                    <button @click="
+            <div class="flex space-x-2 rtl:space-x-reverse">
+                <button
+                    @click="
                             navigator.clipboard.readText().then(text => {
                                 if (text) {
                                     try {
@@ -81,12 +95,14 @@
                                 console.error('{{ __('Failed to read clipboard contents:') }}', err);
                             });
                             showContextMenu = false;
-                        " class="px-2 py-1 text-xs rounded hover:bg-gray-200 border border-gray-100"
-                        title="{{ __('Paste Before Block') }}">
-                        <x-heroicon-o-arrow-up class="w-3 h-3 inline-block" />
-                        {{ __('Before') }}
-                    </button>
-                    <button @click="
+                        "
+                    class="px-2 py-1 text-xs rounded hover:bg-gray-200 border border-gray-100"
+                    title="{{ __('Paste Before Block') }}">
+                    <x-heroicon-o-arrow-up class="w-3 h-3 inline-block" />
+                    {{ __('Before') }}
+                </button>
+                <button
+                    @click="
                             navigator.clipboard.readText().then(text => {
                                 if (text) {
                                     try {
@@ -108,73 +124,75 @@
                                 console.error('{{ __('Failed to read clipboard contents:') }}', err);
                             });
                             showContextMenu = false;
-                        " class="px-2 py-1 text-xs rounded hover:bg-gray-200 border border-gray-100"
-                        title="{{ __('Paste After Block') }}">
-                        <x-heroicon-o-arrow-down class="w-3 h-3 inline-block" />
-                        {{ __('After') }}
-                    </button>
-                </div>
+                        "
+                    class="px-2 py-1 text-xs rounded hover:bg-gray-200 border border-gray-100"
+                    title="{{ __('Paste After Block') }}">
+                    <x-heroicon-o-arrow-down class="w-3 h-3 inline-block" />
+                    {{ __('After') }}
+                </button>
             </div>
+        </div>
 
-            <button @click="
+        <button
+            @click="
                 showContextMenu = false;
                 confirm('{{ __('Are you sure you want to delete this block?') }}') 
                 && $dispatch('deleteBlock', { blockId: '{{ $blockId }}'}); 
                 "
-                class="flex items-center w-full px-4 py-2 text-left text-sm text-red-600 hover:bg-red-50 border-b border-gray-50">
-                <x-heroicon-o-trash class="w-4 h-4 ms-0 me-3 text-red-500" />
-                <span>{{ __('Delete') }}</span>
-            </button>
+            class="flex items-center w-full px-4 py-2 text-left text-sm text-red-600 hover:bg-red-50 border-b border-gray-50">
+            <x-heroicon-o-trash class="w-4 h-4 ms-0 me-3 text-red-500" />
+            <span>{{ __('Delete') }}</span>
+        </button>
 
-            <div class="border-t border-gray-200 my-1"></div>
+        <div class="border-t border-gray-200 my-1"></div>
 
-            <!-- Move Block (combined Up/Down options) -->
-            <div class="flex items-center w-full px-4 py-2 text-sm text-gray-700 border-b border-gray-50">
-                <div class="flex items-center flex-1">
-                    <x-heroicon-o-arrows-up-down class="w-4 h-4 ms-0 me-3 text-gray-500" />
-                    <span>{{ __('Move') }}</span>
-                </div>
-                <div class="flex space-x-2 rtl:space-x-reverse">
-                    <button
-                        wire:click="$dispatch('moveBlockUp', { blockId: '{{ $blockId }}'}); showContextMenu = false;"
-                        class="px-2 py-1 text-xs rounded hover:bg-gray-200 border border-gray-100"
-                        title="{{ __('Move Block Up') }}">
-                        <x-heroicon-o-arrow-up class="w-3 h-3 inline-block" />
-                        {{ __('Up') }}
-                    </button>
-                    <button
-                        wire:click="$dispatch('moveBlockDown', { blockId: '{{ $blockId }}'}); showContextMenu = false;"
-                        class="px-2 py-1 text-xs rounded hover:bg-gray-200 border border-gray-100"
-                        title="{{ __('Move Block Down') }}">
-                        <x-heroicon-o-arrow-down class="w-3 h-3 inline-block" />
-                        {{ __('Down') }}
-                    </button>
-                </div>
+        <!-- Move Block (combined Up/Down options) -->
+        <div class="flex items-center w-full px-4 py-2 text-sm text-gray-700 border-b border-gray-50">
+            <div class="flex items-center flex-1">
+                <x-heroicon-o-arrows-up-down class="w-4 h-4 ms-0 me-3 text-gray-500" />
+                <span>{{ __('Move') }}</span>
             </div>
+            <div class="flex space-x-2 rtl:space-x-reverse">
+                <button
+                    wire:click="$dispatch('moveBlockUp', { blockId: '{{ $blockId }}'}); showContextMenu = false;"
+                    class="px-2 py-1 text-xs rounded hover:bg-gray-200 border border-gray-100"
+                    title="{{ __('Move Block Up') }}">
+                    <x-heroicon-o-arrow-up class="w-3 h-3 inline-block" />
+                    {{ __('Up') }}
+                </button>
+                <button
+                    wire:click="$dispatch('moveBlockDown', { blockId: '{{ $blockId }}'}); showContextMenu = false;"
+                    class="px-2 py-1 text-xs rounded hover:bg-gray-200 border border-gray-100"
+                    title="{{ __('Move Block Down') }}">
+                    <x-heroicon-o-arrow-down class="w-3 h-3 inline-block" />
+                    {{ __('Down') }}
+                </button>
+            </div>
+        </div>
 
-            <!-- Add Block (combined Before/After options) -->
-            <div class="flex items-center w-full px-4 py-2 text-sm text-green-600">
-                <div class="flex items-center flex-1">
-                    <x-heroicon-o-plus class="w-4 h-4 ms-0 me-3 text-green-500" />
-                    <span>{{ __('Add Block') }}</span>
-                </div>
-                <div class="flex space-x-2 rtl:space-x-reverse">
-                    <button
-                        wire:click="$dispatch('openBlockModal', { rowId: '{{ $rowId }}', beforeBlockId: '{{ $blockId }}' }); showContextMenu = false;"
-                        class="px-2 py-1 text-xs rounded hover:bg-green-50 border border-green-100"
-                        title="{{ __('Add Block Before') }}">
-                        <x-heroicon-o-arrow-up class="w-3 h-3 inline-block" />
-                        {{ __('Before') }}
-                    </button>
-                    <button
-                        wire:click="$dispatch('openBlockModal', { rowId: '{{ $rowId }}', afterBlockId: '{{ $blockId }}' }); showContextMenu = false;"
-                        class="px-2 py-1 text-xs rounded hover:bg-green-50 border border-green-100"
-                        title="{{ __('Add Block After') }}">
-                        <x-heroicon-o-arrow-down class="w-3 h-3 inline-block" />
-                        {{ __('After') }}
-                    </button>
-                </div>
+        <!-- Add Block (combined Before/After options) -->
+        <div class="flex items-center w-full px-4 py-2 text-sm text-green-600">
+            <div class="flex items-center flex-1">
+                <x-heroicon-o-plus class="w-4 h-4 ms-0 me-3 text-green-500" />
+                <span>{{ __('Add Block') }}</span>
+            </div>
+            <div class="flex space-x-2 rtl:space-x-reverse">
+                <button
+                    wire:click="$dispatch('openBlockModal', { rowId: '{{ $rowId }}', beforeBlockId: '{{ $blockId }}' }); showContextMenu = false;"
+                    class="px-2 py-1 text-xs rounded hover:bg-green-50 border border-green-100"
+                    title="{{ __('Add Block Before') }}">
+                    <x-heroicon-o-arrow-up class="w-3 h-3 inline-block" />
+                    {{ __('Before') }}
+                </button>
+                <button
+                    wire:click="$dispatch('openBlockModal', { rowId: '{{ $rowId }}', afterBlockId: '{{ $blockId }}' }); showContextMenu = false;"
+                    class="px-2 py-1 text-xs rounded hover:bg-green-50 border border-green-100"
+                    title="{{ __('Add Block After') }}">
+                    <x-heroicon-o-arrow-down class="w-3 h-3 inline-block" />
+                    {{ __('After') }}
+                </button>
             </div>
         </div>
     </div>
+</div>
 </div>

--- a/resources/views/livewire/builder/page-editor.blade.php
+++ b/resources/views/livewire/builder/page-editor.blade.php
@@ -488,7 +488,7 @@
                     }"
                     style="font-size:0">
                     @foreach ($rows as $rowId => $row)
-                        <livewire:row-block :edit-mode="true" :blocks="$row['blocks']" :rowId="$rowId" :properties="$row['properties']"
+                        <livewire:row-block :edit-mode="true" :blocks="$row['blocks']" :rowId="$rowId" :properties="$row['properties'] ?? []"
                             :key="$rowId" />
                     @endforeach
                 </div>

--- a/resources/views/livewire/builder/row.blade.php
+++ b/resources/views/livewire/builder/row.blade.php
@@ -205,6 +205,7 @@
                         'blockId' => $blockId,
                         'rowId' => $rowId,
                         'properties' => $block['properties'] ?? [],
+                        'blocks' => $block['blocks'] ?? [], // Pass nested blocks for RowBlock
                         'editMode' => true,
                     ],
                     key($blockId)

--- a/resources/views/livewire/builder/row.blade.php
+++ b/resources/views/livewire/builder/row.blade.php
@@ -8,7 +8,7 @@
     <div class="block-row-inner">
         <!-- Elementor-style Row Controls -->
         <div
-            class="absolute top-[-35px] left-1/2 -translate-x-1/2 bg-pink-500 shadow-lg px-1 py-1 rounded-lg flex items-center space-x-1 z-50 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none group-hover:pointer-events-auto">
+            class="absolute top-[-15px] left-1/2 -translate-x-1/2 bg-pink-500 shadow-lg px-1 py-1 rounded-lg flex items-center space-x-1 z-50 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none group-hover:pointer-events-auto">
             <!-- Select Button -->
             <button wire:click="rowSelected()"
                 class="w-7 h-7 flex items-center justify-center text-white hover:bg-pink-600 rounded transition-colors duration-150"
@@ -196,7 +196,7 @@
             </div>
         </div>
 
-        <div class="row-blocks pt-4 pb-4 {{ $rowCssClasses }}">
+        <div class="row-blocks pt-10 pb-10 {{ $rowCssClasses }}">
             @foreach ($blocks as $blockId => $block)
                 @livewire(
                     'builder-block',

--- a/src/Http/Livewire/BlockProperties/FlexibleSizeProperty.php
+++ b/src/Http/Livewire/BlockProperties/FlexibleSizeProperty.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Trinavo\LivewirePageBuilder\Http\Livewire\BlockProperties;
+
+use Livewire\Component;
+
+class FlexibleSizeProperty extends Component
+{
+    public $property;
+    public $value;
+    public $rowId;
+    public $blockId;
+    public $mode = 'class'; // 'class' or 'custom'
+    public $customValue = '';
+    public $selectedClass = '';
+    public $prefix = 'w'; // Will be set based on property name
+
+    public function mount($property, $value = null, $rowId = null, $blockId = null)
+    {
+        $this->property = $property;
+        $this->value = $value;
+        $this->rowId = $rowId;
+        $this->blockId = $blockId;
+
+        // Determine the Tailwind prefix based on property name
+        $this->prefix = $this->determineTailwindPrefix($property['name']);
+
+        // Initialize to empty state
+        $this->selectedClass = '';
+        $this->customValue = '';
+
+        // Determine mode based on current value
+        if ($value && $value !== '') {
+            // Check if value is a predefined class
+            if (isset($this->property['classes']) && array_key_exists($value, $this->property['classes'])) {
+                $this->mode = 'class';
+                $this->selectedClass = $value;
+            } else {
+                // It's a custom value (arbitrary value or numeric)
+                $this->mode = 'custom';
+
+                // Extract numeric value from Tailwind arbitrary value syntax
+                // e.g., "w-[100px]" -> "100", "h-[200px]" -> "200"
+                if (preg_match('/\[(\d+(?:\.\d+)?)(?:px|rem|em|%)?\]/', $value, $matches)) {
+                    $this->customValue = $matches[1];
+                } elseif (is_numeric($value)) {
+                    // Direct numeric value (backward compatibility)
+                    $this->customValue = $value;
+                } else {
+                    // Try to extract any numeric value as fallback
+                    $this->customValue = preg_replace('/[^0-9.]/', '', $value);
+                    if (!$this->customValue) {
+                        // If we couldn't extract a value, it might be an unrecognized class
+                        // Default to class mode with the first option
+                        $this->mode = 'class';
+                        if (!empty($this->property['classes'])) {
+                            $this->selectedClass = array_key_first($this->property['classes']);
+                        }
+                    }
+                }
+            }
+        } else {
+            // No value set, default to class mode
+            $this->mode = 'class';
+            // Don't auto-select a class, let user choose
+        }
+    }
+
+    protected function determineTailwindPrefix($propertyName)
+    {
+        // Determine prefix based on property name
+        if (str_contains(strtolower($propertyName), 'width')) {
+            return 'w';
+        } elseif (str_contains(strtolower($propertyName), 'minheight')) {
+            return 'min-h';
+        } elseif (str_contains(strtolower($propertyName), 'height')) {
+            return 'h';
+        }
+
+        return 'w'; // Default to width
+    }
+
+    public function updatedMode()
+    {
+        if ($this->mode === 'class') {
+            $this->customValue = '';
+            // If switching to class mode and no class is selected, don't update the value yet
+            if ($this->selectedClass) {
+                $this->updateValue($this->selectedClass);
+            }
+        } else {
+            $this->selectedClass = '';
+            // If switching to custom mode and no custom value, don't update yet
+            if ($this->customValue) {
+                $this->updateValue($this->generateTailwindArbitraryValue());
+            }
+        }
+    }
+
+    public function updatedSelectedClass()
+    {
+        if ($this->mode === 'class' && $this->selectedClass) {
+            $this->updateValue($this->selectedClass);
+        }
+    }
+
+    public function updatedCustomValue()
+    {
+        if ($this->mode === 'custom') {
+            // Allow clearing the value
+            if ($this->customValue === '' || $this->customValue === null) {
+                $this->updateValue('');
+            } else {
+                $this->updateValue($this->generateTailwindArbitraryValue());
+            }
+        }
+    }
+
+    protected function generateTailwindArbitraryValue()
+    {
+        if (!$this->customValue) {
+            return '';
+        }
+
+        // Generate Tailwind arbitrary value syntax
+        // e.g., w-[100px], h-[200px], min-h-[300px]
+        return $this->prefix . '-[' . $this->customValue . $this->property['unit'] . ']';
+    }
+
+    protected function updateValue($newValue)
+    {
+        $this->value = $newValue;
+        $this->dispatch('updateBlockProperty', $this->rowId, $this->blockId, $this->property['name'], $newValue);
+    }
+
+    public function render()
+    {
+        return view('page-builder::livewire.builder.block-properties.flexible-size-property');
+    }
+}

--- a/src/Http/Livewire/BuilderBlock.php
+++ b/src/Http/Livewire/BuilderBlock.php
@@ -16,6 +16,8 @@ class BuilderBlock extends Component
 
     public ?array $properties;
 
+    public ?array $blocks = []; // For nested rows
+
     public $cssClasses;
 
     public $inlineStyles;
@@ -28,8 +30,15 @@ class BuilderBlock extends Component
         if (class_exists($blockClass)) {
             $block = app($blockClass);
             $this->properties = $this->properties ?? $block->getPropertyValues();
-            $this->cssClasses = $this->makeClasses();
-            $this->inlineStyles = $this->makeInlineStyles();
+
+            // Don't apply CSS classes to RowBlocks - they manage their own styling
+            if ($blockClass !== \Trinavo\LivewirePageBuilder\Http\Livewire\RowBlock::class) {
+                $this->cssClasses = $this->makeClasses();
+                $this->inlineStyles = $this->makeInlineStyles();
+            } else {
+                $this->cssClasses = '';
+                $this->inlineStyles = '';
+            }
         }
     }
 
@@ -38,11 +47,21 @@ class BuilderBlock extends Component
         $blockClass = $this->getBlockClass();
         $this->properties['editMode'] = $this->editMode;
 
+        $componentProperties = $this->properties;
+
+        // For RowBlock, add the nested blocks
+        if ($blockClass === \Trinavo\LivewirePageBuilder\Http\Livewire\RowBlock::class) {
+            $componentProperties['blocks'] = $this->blocks ?? [];
+            $componentProperties['rowId'] = $this->blockId; // Use block ID as row ID for nested rows
+        }
+
         return view('page-builder::livewire.builder.builder-block', [
             'blockAlias' => $this->blockAlias,
             'blockId' => $this->blockId,
             'editMode' => $this->editMode,
             'classExists' => class_exists($blockClass),
+            'componentProperties' => $componentProperties,
+            'isRowBlock' => $blockClass === \Trinavo\LivewirePageBuilder\Http\Livewire\RowBlock::class,
         ]);
     }
 
@@ -83,8 +102,12 @@ class BuilderBlock extends Component
         }
         $this->properties[$propertyName] = $value;
 
-        $this->cssClasses = $this->makeClasses();
-        $this->inlineStyles = $this->makeInlineStyles();
+        // Don't update CSS classes for RowBlocks - they manage their own styling
+        $blockClass = $this->getBlockClass();
+        if ($blockClass !== \Trinavo\LivewirePageBuilder\Http\Livewire\RowBlock::class) {
+            $this->cssClasses = $this->makeClasses();
+            $this->inlineStyles = $this->makeInlineStyles();
+        }
     }
 
     public function makeClasses(): string

--- a/src/Http/Livewire/PageEditor.php
+++ b/src/Http/Livewire/PageEditor.php
@@ -2,6 +2,7 @@
 
 namespace Trinavo\LivewirePageBuilder\Http\Livewire;
 
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Livewire\Attributes\On;
 use Livewire\Component;
@@ -177,10 +178,21 @@ class PageEditor extends Component
             $properties['blockPageName'] = $blockPageName;
         }
         $blockId = uniqid();
-        $block = [
-            'alias' => $blockAlias,
-            'properties' => $properties,
-        ];
+
+        // Special handling for nested rows
+        if ($blockClass === \Trinavo\LivewirePageBuilder\Http\Livewire\RowBlock::class) {
+            $block = [
+                'alias' => $blockAlias,
+                'properties' => $properties,
+                'blocks' => [], // Nested rows start with empty blocks
+            ];
+        } else {
+            $block = [
+                'alias' => $blockAlias,
+                'properties' => $properties,
+            ];
+        }
+
         if ($this->beforeBlockId) {
             $blockIds = array_keys($this->rows[$rowId]['blocks']);
             $position = array_search($this->beforeBlockId, $blockIds);
@@ -283,20 +295,66 @@ class PageEditor extends Component
     public function addBlockToModalRow($blockAlias, $blockPageName = null)
     {
         if ($this->modalRowId) {
-            $this->addBlockToRow($this->modalRowId, $blockAlias, $blockPageName);
+            // Check if this is a top-level row
+            if (isset($this->rows[$this->modalRowId])) {
+                $this->addBlockToRow($this->modalRowId, $blockAlias, $blockPageName);
+            } else {
+                // This is a nested row, dispatch event for RowBlock components to handle
+                $this->dispatch('add-block-to-nested-row',
+                    rowId: $this->modalRowId,
+                    blockAlias: $blockAlias,
+                    blockPageName: $blockPageName
+                );
+            }
             $this->closeBlockModal();
         }
+    }
+
+    #[On('sync-nested-row-data')]
+    public function syncNestedRowData($nestedRowId, $blocks)
+    {
+        // Find the nested row in the structure and update its blocks
+        $this->updateNestedRowBlocks($this->rows, $nestedRowId, $blocks);
+    }
+
+    private function updateNestedRowBlocks(&$structure, $nestedRowId, $blocks)
+    {
+        foreach ($structure as $rowId => $row) {
+            if (isset($row['blocks'])) {
+                foreach ($row['blocks'] as $blockId => $block) {
+                    // Check if this block is the nested row we're looking for
+                    if ($blockId === $nestedRowId) {
+                        $structure[$rowId]['blocks'][$blockId]['blocks'] = $blocks;
+                        return true;
+                    }
+
+                    // If this block has nested blocks, recursively search
+                    if (isset($block['blocks'])) {
+                        $nestedBlocks = &$structure[$rowId]['blocks'][$blockId]['blocks'];
+                        if ($this->updateNestedRowBlocks($nestedBlocks, $nestedRowId, $blocks)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     #[On('updateBlockProperty')]
     public function updateBlockProperty($rowId, $blockId, $propertyName, $value)
     {
-        if ($rowId) {
-            $this->rows[$rowId]['properties'][$propertyName] = $value;
+        if ($rowId && !$blockId) {
+            // Updating row properties - only handle top-level rows
+            if (isset($this->rows[$rowId])) {
+                $this->rows[$rowId]['properties'][$propertyName] = $value;
+            }
+            // Nested rows will handle their own properties via their RowBlock component
         } else {
-            foreach ($this->rows as $rowId => $row) {
+            // Updating block properties
+            foreach ($this->rows as $rId => $row) {
                 if (isset($row['blocks'][$blockId])) {
-                    $this->rows[$rowId]['blocks'][$blockId]['properties'][$propertyName] = $value;
+                    $this->rows[$rId]['blocks'][$blockId]['properties'][$propertyName] = $value;
                     break;
                 }
             }
@@ -604,28 +662,38 @@ class PageEditor extends Component
         $blocks = [];
         foreach ($this->rows as $rowId => $row) {
             if (isset($row['blocks'])) {
-                foreach ($row['blocks'] as $blockId => $block) {
-                    $blockClass = app(PageBuilderService::class)->getClassNameFromAlias($block['alias']);
-                    if (! $blockClass) {
-                        continue;
-                    }
-
-                    $blockInstance = app($blockClass);
-                    $label = $blockInstance->getPageBuilderLabel();
-                    $icon = $blockInstance->getPageBuilderIcon() ?? 'heroicon-o-cube';
-
-                    $blocks[] = [
-                        'id' => $blockId,
-                        'rowId' => $rowId,
-                        'alias' => $block['alias'],
-                        'label' => $label,
-                        'icon' => $icon,
-                    ];
-                }
+                $this->collectBlocksRecursively($row['blocks'], $rowId, $blocks);
             }
         }
 
         return $blocks;
+    }
+
+    private function collectBlocksRecursively($blocksList, $parentRowId, &$blocks)
+    {
+        foreach ($blocksList as $blockId => $block) {
+            $blockClass = app(PageBuilderService::class)->getClassNameFromAlias($block['alias']);
+            if (! $blockClass) {
+                continue;
+            }
+
+            $blockInstance = app($blockClass);
+            $label = $blockInstance->getPageBuilderLabel();
+            $icon = $blockInstance->getPageBuilderIcon() ?? 'heroicon-o-cube';
+
+            $blocks[] = [
+                'id' => $blockId,
+                'rowId' => $parentRowId,
+                'alias' => $block['alias'],
+                'label' => $label,
+                'icon' => $icon,
+            ];
+
+            // If this block is a RowBlock (nested row), recursively collect its blocks
+            if ($blockClass === \Trinavo\LivewirePageBuilder\Http\Livewire\RowBlock::class && isset($block['blocks'])) {
+                $this->collectBlocksRecursively($block['blocks'], $blockId, $blocks);
+            }
+        }
     }
 
     /**
@@ -831,25 +899,7 @@ class PageEditor extends Component
         $grouped = [];
 
         foreach ($this->rows as $rowId => $row) {
-            $blocks = [];
-
-            foreach ($row['blocks'] as $blockId => $block) {
-                $blockClass = app(PageBuilderService::class)->getClassNameFromAlias($block['alias']);
-                if (! $blockClass) {
-                    continue;
-                }
-
-                $blockInstance = app($blockClass);
-                $label = $blockInstance->getPageBuilderLabel();
-                $icon = $blockInstance->getPageBuilderIcon() ?? 'heroicon-o-cube';
-
-                $blocks[] = [
-                    'id' => $blockId,
-                    'alias' => $block['alias'],
-                    'label' => $label,
-                    'icon' => $icon,
-                ];
-            }
+            $blocks = $this->getBlocksWithNesting($row['blocks']);
 
             $grouped[$rowId] = [
                 'blocks' => $blocks,
@@ -857,5 +907,41 @@ class PageEditor extends Component
         }
 
         return $grouped;
+    }
+
+    private function getBlocksWithNesting($blocksList)
+    {
+        $blocks = [];
+
+        foreach ($blocksList as $blockId => $block) {
+            $blockClass = app(PageBuilderService::class)->getClassNameFromAlias($block['alias']);
+            if (! $blockClass) {
+                continue;
+            }
+
+            $blockInstance = app($blockClass);
+            $label = $blockInstance->getPageBuilderLabel();
+            $icon = $blockInstance->getPageBuilderIcon() ?? 'heroicon-o-cube';
+
+            $blockData = [
+                'id' => $blockId,
+                'alias' => $block['alias'],
+                'label' => $label,
+                'icon' => $icon,
+            ];
+
+            // If this block is a RowBlock (nested row), add its nested blocks
+            if ($blockClass === \Trinavo\LivewirePageBuilder\Http\Livewire\RowBlock::class && isset($block['blocks'])) {
+                Log::info('Found nested row with blocks:', [
+                    'blockId' => $blockId,
+                    'nestedBlocks' => $block['blocks']
+                ]);
+                $blockData['nestedBlocks'] = $this->getBlocksWithNesting($block['blocks']);
+            }
+
+            $blocks[] = $blockData;
+        }
+
+        return $blocks;
     }
 }

--- a/src/Http/Livewire/RowBlock.php
+++ b/src/Http/Livewire/RowBlock.php
@@ -47,25 +47,91 @@ class RowBlock extends Block
     public function mount()
     {
         $this->properties = $this->properties ?? $this->getPropertyValues();
+        $this->blocks = $this->blocks ?? [];
         $this->cssClasses = $this->makeClasses();
         $this->inlineStyles = $this->makeInlineStyles();
     }
 
     public function openBlockModal()
     {
-        $this->dispatch('openBlockModal', $this->rowId)->to('page-editor');
+        $this->dispatch('openBlockModal', $this->rowId);
+    }
+
+    public function addBlockToThisRow($blockAlias, $blockPageName = null)
+    {
+        $blockClass = app(PageBuilderService::class)->getClassNameFromAlias($blockAlias);
+        if (!$blockClass) {
+            return;
+        }
+
+        $properties = app($blockClass)->getPropertyValues();
+        if ($blockPageName) {
+            $properties['blockPageName'] = $blockPageName;
+        }
+        $blockId = uniqid();
+
+        // Special handling for nested rows
+        if ($blockClass === \Trinavo\LivewirePageBuilder\Http\Livewire\RowBlock::class) {
+            $block = [
+                'alias' => $blockAlias,
+                'properties' => $properties,
+                'blocks' => [], // Nested rows start with empty blocks
+            ];
+        } else {
+            $block = [
+                'alias' => $blockAlias,
+                'properties' => $properties,
+            ];
+        }
+
+        $this->blocks[$blockId] = $block;
+
+        // Sync changes back to parent structure
+        $this->dispatch('sync-nested-row-data',
+            nestedRowId: $this->rowId,
+            blocks: $this->blocks
+        );
+
+        // Dispatch to notify that a block was added
+        $this->dispatch(
+            'block-added',
+            rowId: $this->rowId,
+            blockId: $blockId,
+            blockAlias: $blockAlias,
+            properties: $block['properties']
+        );
+    }
+
+    #[On('add-block-to-nested-row')]
+    public function addBlockToNestedRow($rowId, $blockAlias, $blockPageName = null)
+    {
+        if ($rowId === $this->rowId) {
+            $this->addBlockToThisRow($blockAlias, $blockPageName);
+        }
     }
 
     #[On('updateBlockProperty')]
     public function updateBlockProperty($rowId, $blockId, $propertyName, $value)
     {
-        if ($blockId || $rowId != $this->rowId) {
+        // Handle row property updates (when this RowBlock is being treated as a row)
+        if ($rowId == $this->rowId && !$blockId) {
+            $this->properties[$propertyName] = $value;
+            $this->cssClasses = $this->makeClasses();
+            $this->inlineStyles = $this->makeInlineStyles();
             return;
         }
-        $this->properties[$propertyName] = $value;
 
-        $this->cssClasses = $this->makeClasses();
-        $this->inlineStyles = $this->makeInlineStyles();
+        // Handle block property updates within this row
+        if ($blockId && isset($this->blocks[$blockId])) {
+            $this->blocks[$blockId]['properties'][$propertyName] = $value;
+
+            // Sync changes back to parent structure
+            $this->dispatch('sync-nested-row-data',
+                nestedRowId: $this->rowId,
+                blocks: $this->blocks
+            );
+            return;
+        }
     }
 
     public function render()
@@ -131,11 +197,21 @@ class RowBlock extends Block
             return;
         }
 
-        if ($beforeBlockId) {
+        // Special handling for nested rows
+        if ($blockAlias === 'trinavo-livewire-page-builder-http-livewire-row-block') {
+            $block = [
+                'alias' => $blockAlias,
+                'properties' => $properties,
+                'blocks' => [], // Nested rows start with empty blocks
+            ];
+        } else {
             $block = [
                 'alias' => $blockAlias,
                 'properties' => $properties,
             ];
+        }
+
+        if ($beforeBlockId) {
             $blockIds = array_keys($this->blocks);
             $position = array_search($beforeBlockId, $blockIds);
 
@@ -149,10 +225,6 @@ class RowBlock extends Block
             }
             $this->blocks = $newBlocks;
         } elseif ($afterBlockId) {
-            $block = [
-                'alias' => $blockAlias,
-                'properties' => $properties,
-            ];
             $blockIds = array_keys($this->blocks);
             $position = array_search($afterBlockId, $blockIds);
 
@@ -166,10 +238,7 @@ class RowBlock extends Block
             }
             $this->blocks = $newBlocks;
         } else {
-            $this->blocks[$blockId] = [
-                'alias' => $blockAlias,
-                'properties' => $properties,
-            ];
+            $this->blocks[$blockId] = $block;
         }
     }
 
@@ -178,6 +247,12 @@ class RowBlock extends Block
     {
         if (isset($this->blocks[$blockId])) {
             unset($this->blocks[$blockId]);
+
+            // Sync changes back to parent structure
+            $this->dispatch('sync-nested-row-data',
+                nestedRowId: $this->rowId,
+                blocks: $this->blocks
+            );
         }
     }
 
@@ -335,5 +410,15 @@ class RowBlock extends Block
             message: 'Row copied to clipboard',
             type: 'success'
         );
+    }
+
+    public function getPageBuilderLabel(): string
+    {
+        return 'Row';
+    }
+
+    public function getPageBuilderIcon(): string
+    {
+        return 'heroicon-o-rectangle-group';
     }
 }

--- a/src/Providers/PageBuilderServiceProvider.php
+++ b/src/Providers/PageBuilderServiceProvider.php
@@ -9,6 +9,7 @@ use Trinavo\LivewirePageBuilder\Config\Variables;
 use Trinavo\LivewirePageBuilder\Console\InstallPageBuilderCommand;
 use Trinavo\LivewirePageBuilder\Http\Livewire\BlockProperties;
 use Trinavo\LivewirePageBuilder\Http\Livewire\BlockProperties\ColorPicker;
+use Trinavo\LivewirePageBuilder\Http\Livewire\BlockProperties\FlexibleSizeProperty;
 use Trinavo\LivewirePageBuilder\Http\Livewire\BlockProperties\ImageProperty;
 use Trinavo\LivewirePageBuilder\Http\Livewire\BlockProperties\RichTextProperty;
 use Trinavo\LivewirePageBuilder\Http\Livewire\BlockProperties\SelectProperty;
@@ -164,6 +165,7 @@ class PageBuilderServiceProvider extends ServiceProvider
         Livewire::component('row-block', RowBlock::class);
         Livewire::component('builder-page-block', BuilderPageBlock::class);
         Livewire::component('block-properties.color-picker', ColorPicker::class);
+        Livewire::component('block-properties.flexible-size-property', FlexibleSizeProperty::class);
         Livewire::component('block-properties.image-property', ImageProperty::class);
         Livewire::component('block-properties.select-property', SelectProperty::class);
         Livewire::component('block-properties.richtext-property', RichTextProperty::class);

--- a/src/Services/PageBuilderService.php
+++ b/src/Services/PageBuilderService.php
@@ -7,6 +7,7 @@ use Livewire\Livewire;
 use Trinavo\LivewirePageBuilder\Blocks\RichText;
 use Trinavo\LivewirePageBuilder\Blocks\Section;
 use Trinavo\LivewirePageBuilder\Http\Livewire\BuilderPageBlock;
+use Trinavo\LivewirePageBuilder\Http\Livewire\RowBlock;
 
 class PageBuilderService
 {
@@ -51,6 +52,7 @@ class PageBuilderService
         $blocks = config('page-builder.blocks', []);
         $blocks[] = Section::class;
         $blocks[] = RichText::class;
+        $blocks[] = RowBlock::class;
 
         return $blocks;
     }

--- a/src/Services/PageBuilderService.php
+++ b/src/Services/PageBuilderService.php
@@ -257,15 +257,16 @@ class PageBuilderService
         $tabletWidth = $properties['tabletWidth'] ?? 'w-auto';
         $desktopWidth = $properties['desktopWidth'] ?? 'w-auto';
 
-        $classes[] = $mobileWidth;
+        // Format width values (in case they are custom arbitrary values or classes)
+        $classes[] = $this->formatSizeValue($mobileWidth, 'w');
 
         // Only add tablet/desktop widths if they're different from mobile
         if ($tabletWidth !== $mobileWidth) {
-            $classes[] = '@3xl:'.$tabletWidth;
+            $classes[] = '@3xl:'.$this->formatSizeValue($tabletWidth, 'w');
         }
 
         if ($desktopWidth !== $tabletWidth) {
-            $classes[] = '@5xl:'.$desktopWidth;
+            $classes[] = '@5xl:'.$this->formatSizeValue($desktopWidth, 'w');
         }
 
         return $classes;
@@ -321,30 +322,58 @@ class PageBuilderService
         $desktopMinHeight = $properties['desktopMinHeight'] ?? null;
 
         $classes = [];
+
+        // Handle height values
         if ($mobileHeight) {
-            $classes[] = 'h-['.$mobileHeight.'px]';
+            $classes[] = $this->formatSizeValue($mobileHeight, 'h');
         }
 
         if ($tabletHeight && $tabletHeight !== $mobileHeight) {
-            $classes[] = '@3xl:h-['.$tabletHeight.'px]';
+            $classes[] = '@3xl:'.$this->formatSizeValue($tabletHeight, 'h');
         }
 
         if ($desktopHeight && $desktopHeight !== $tabletHeight) {
-            $classes[] = '@5xl:h-['.$desktopHeight.'px]';
+            $classes[] = '@5xl:'.$this->formatSizeValue($desktopHeight, 'h');
         }
 
+        // Handle min-height values
         if ($mobileMinHeight) {
-            $classes[] = 'min-h-['.$mobileMinHeight.'px]';
+            $classes[] = $this->formatSizeValue($mobileMinHeight, 'min-h');
         }
 
         if ($tabletMinHeight && $tabletMinHeight !== $mobileMinHeight) {
-            $classes[] = '@3xl:min-h-['.$tabletMinHeight.'px]';
+            $classes[] = '@3xl:'.$this->formatSizeValue($tabletMinHeight, 'min-h');
         }
 
         if ($desktopMinHeight && $desktopMinHeight !== $tabletMinHeight) {
-            $classes[] = '@5xl:min-h-['.$desktopMinHeight.'px]';
+            $classes[] = '@5xl:'.$this->formatSizeValue($desktopMinHeight, 'min-h');
         }
 
         return implode(' ', $classes);
+    }
+
+    /**
+     * Format a size value - if it's already a Tailwind class, return as-is,
+     * otherwise convert numeric value to arbitrary value syntax
+     */
+    protected function formatSizeValue($value, $prefix): string
+    {
+        // If value is null or empty, return empty string
+        if (! $value) {
+            return '';
+        }
+
+        // Check if it's already a Tailwind class (starts with expected prefix)
+        if (str_starts_with($value, $prefix.'-')) {
+            return $value;
+        }
+
+        // Check if it's a numeric value (for backward compatibility)
+        if (is_numeric($value)) {
+            return $prefix.'-['.$value.'px]';
+        }
+
+        // Return as-is (might be a custom format)
+        return $value;
     }
 }

--- a/src/Support/Block.php
+++ b/src/Support/Block.php
@@ -7,6 +7,7 @@ use Livewire\Component;
 use Trinavo\LivewirePageBuilder\Services\PageBuilderService;
 use Trinavo\LivewirePageBuilder\Support\Properties\CheckboxProperty;
 use Trinavo\LivewirePageBuilder\Support\Properties\ColorProperty;
+use Trinavo\LivewirePageBuilder\Support\Properties\FlexibleSizeProperty;
 use Trinavo\LivewirePageBuilder\Support\Properties\ImageProperty;
 use Trinavo\LivewirePageBuilder\Support\Properties\SelectProperty;
 use Trinavo\LivewirePageBuilder\Support\Properties\TextProperty;
@@ -109,27 +110,29 @@ abstract class Block extends Component
     protected function getResponsiveProperties(): array
     {
         $widths = $this->getPageBuilderWidthList();
+        $heights = $this->getPageBuilderHeightList();
+        $minHeights = $this->getPageBuilderMinHeightList();
 
         return [
-            (new SelectProperty('mobileWidth', 'Mobile', $widths, defaultValue: $this->mobileWidth))
+            (new FlexibleSizeProperty('mobileWidth', 'Mobile', $widths, allowCustom: true, unit: 'px', defaultValue: $this->mobileWidth))
                 ->setGroup('width', 'Width', 3, 'heroicon-o-device-phone-mobile'),
-            (new SelectProperty('tabletWidth', 'Tablet', $widths, defaultValue: $this->tabletWidth))
+            (new FlexibleSizeProperty('tabletWidth', 'Tablet', $widths, allowCustom: true, unit: 'px', defaultValue: $this->tabletWidth))
                 ->setGroup('width', 'Width', 3, 'heroicon-o-device-tablet'),
-            (new SelectProperty('desktopWidth', 'Desktop', $widths, defaultValue: $this->desktopWidth))
+            (new FlexibleSizeProperty('desktopWidth', 'Desktop', $widths, allowCustom: true, unit: 'px', defaultValue: $this->desktopWidth))
                 ->setGroup('width', 'Width', 3, 'heroicon-o-device-desktop'),
 
-            (new TextProperty('mobileHeight', 'Mobile', numeric: true, defaultValue: $this->mobileHeight, min: 0))
+            (new FlexibleSizeProperty('mobileHeight', 'Mobile', $heights, allowCustom: true, unit: 'px', defaultValue: $this->mobileHeight))
                 ->setGroup('height', 'Height', 3, 'heroicon-o-device-phone-mobile'),
-            (new TextProperty('tabletHeight', 'Tablet', numeric: true, defaultValue: $this->tabletHeight, min: 0))
+            (new FlexibleSizeProperty('tabletHeight', 'Tablet', $heights, allowCustom: true, unit: 'px', defaultValue: $this->tabletHeight))
                 ->setGroup('height', 'Height', 3, 'heroicon-o-device-tablet'),
-            (new TextProperty('desktopHeight', 'Desktop', numeric: true, defaultValue: $this->desktopHeight, min: 0))
+            (new FlexibleSizeProperty('desktopHeight', 'Desktop', $heights, allowCustom: true, unit: 'px', defaultValue: $this->desktopHeight))
                 ->setGroup('height', 'Height', 3, 'heroicon-o-device-desktop'),
 
-            (new TextProperty('mobileMinHeight', 'Mobile', numeric: true, defaultValue: $this->mobileMinHeight, min: 0))
+            (new FlexibleSizeProperty('mobileMinHeight', 'Mobile', $minHeights, allowCustom: true, unit: 'px', defaultValue: $this->mobileMinHeight))
                 ->setGroup('min_height', 'Min Height', 3, 'heroicon-o-device-phone-mobile'),
-            (new TextProperty('tabletMinHeight', 'Tablet', numeric: true, defaultValue: $this->tabletMinHeight, min: 0))
+            (new FlexibleSizeProperty('tabletMinHeight', 'Tablet', $minHeights, allowCustom: true, unit: 'px', defaultValue: $this->tabletMinHeight))
                 ->setGroup('min_height', 'Min Height', 3, 'heroicon-o-device-tablet'),
-            (new TextProperty('desktopMinHeight', 'Desktop', numeric: true, defaultValue: $this->desktopMinHeight, min: 0))
+            (new FlexibleSizeProperty('desktopMinHeight', 'Desktop', $minHeights, allowCustom: true, unit: 'px', defaultValue: $this->desktopMinHeight))
                 ->setGroup('min_height', 'Min Height', 3, 'heroicon-o-device-desktop'),
         ];
     }
@@ -312,6 +315,77 @@ abstract class Block extends Component
             'w-6xl' => '6xl (1152px)',
             'w-7xl' => '7xl (1280px)',
             'w-full' => 'full',
+        ];
+    }
+
+    public function getPageBuilderHeightList(): array
+    {
+        return [
+            'h-auto' => 'Auto',
+            'h-fit' => 'Fit Content',
+            'h-full' => 'Full',
+            'h-screen' => 'Screen',
+            'h-svh' => 'Small Viewport Height',
+            'h-lvh' => 'Large Viewport Height',
+            'h-dvh' => 'Dynamic Viewport Height',
+            'h-min' => 'Min Content',
+            'h-max' => 'Max Content',
+            'h-1/2' => '1/2',
+            'h-1/3' => '1/3',
+            'h-2/3' => '2/3',
+            'h-1/4' => '1/4',
+            'h-2/4' => '2/4',
+            'h-3/4' => '3/4',
+            'h-1/5' => '1/5',
+            'h-2/5' => '2/5',
+            'h-3/5' => '3/5',
+            'h-4/5' => '4/5',
+            'h-1/6' => '1/6',
+            'h-2/6' => '2/6',
+            'h-3/6' => '3/6',
+            'h-4/6' => '4/6',
+            'h-5/6' => '5/6',
+            'h-3xs' => '3xs (256px)',
+            'h-2xs' => '2xs (288px)',
+            'h-xs' => 'xs (320px)',
+            'h-sm' => 'sm (384px)',
+            'h-md' => 'md (448px)',
+            'h-lg' => 'lg (512px)',
+            'h-xl' => 'xl (576px)',
+            'h-2xl' => '2xl (672px)',
+            'h-3xl' => '3xl (768px)',
+            'h-4xl' => '4xl (896px)',
+            'h-5xl' => '5xl (1024px)',
+            'h-6xl' => '6xl (1152px)',
+            'h-7xl' => '7xl (1280px)',
+        ];
+    }
+
+    public function getPageBuilderMinHeightList(): array
+    {
+        return [
+            'min-h-0' => 'None',
+            'min-h-full' => 'Full',
+            'min-h-screen' => 'Screen',
+            'min-h-svh' => 'Small Viewport Height',
+            'min-h-lvh' => 'Large Viewport Height',
+            'min-h-dvh' => 'Dynamic Viewport Height',
+            'min-h-min' => 'Min Content',
+            'min-h-max' => 'Max Content',
+            'min-h-fit' => 'Fit Content',
+            'min-h-3xs' => '3xs (256px)',
+            'min-h-2xs' => '2xs (288px)',
+            'min-h-xs' => 'xs (320px)',
+            'min-h-sm' => 'sm (384px)',
+            'min-h-md' => 'md (448px)',
+            'min-h-lg' => 'lg (512px)',
+            'min-h-xl' => 'xl (576px)',
+            'min-h-2xl' => '2xl (672px)',
+            'min-h-3xl' => '3xl (768px)',
+            'min-h-4xl' => '4xl (896px)',
+            'min-h-5xl' => '5xl (1024px)',
+            'min-h-6xl' => '6xl (1152px)',
+            'min-h-7xl' => '7xl (1280px)',
         ];
     }
 

--- a/src/Support/Properties/FlexibleSizeProperty.php
+++ b/src/Support/Properties/FlexibleSizeProperty.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Trinavo\LivewirePageBuilder\Support\Properties;
+
+class FlexibleSizeProperty extends BlockProperty
+{
+    public array $classes = [];
+    public bool $allowCustom = true;
+    public string $unit = 'px';
+
+    public function __construct(
+        string $name,
+        ?string $label = null,
+        array $classes = [],
+        bool $allowCustom = true,
+        string $unit = 'px',
+        $defaultValue = null,
+    ) {
+        parent::__construct($name, $label, $defaultValue);
+        $this->classes = $classes;
+        $this->allowCustom = $allowCustom;
+        $this->unit = $unit;
+    }
+
+    public function getType(): string
+    {
+        return 'flexible-size';
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'label' => $this->label,
+            'type' => $this->getType(),
+            'defaultValue' => $this->defaultValue,
+            'classes' => $this->classes,
+            'allowCustom' => $this->allowCustom,
+            'unit' => $this->unit,
+            'group' => $this->group,
+            'groupLabel' => $this->groupLabel,
+            'groupIcon' => $this->groupIcon,
+            'groupColumns' => $this->groupColumns,
+        ];
+    }
+
+    /**
+     * Create a new instance of this property
+     */
+    public static function make(
+        string $name,
+        ?string $label = null,
+        array $classes = [],
+        bool $allowCustom = true,
+        string $unit = 'px',
+        $defaultValue = null
+    ): static {
+        return new self($name, $label, $classes, $allowCustom, $unit, $defaultValue);
+    }
+}


### PR DESCRIPTION
- Introduced a new FlexibleSizeProperty class to allow users to set width and height with custom values or predefined classes.
- Updated the block-properties Blade template to include a flexible size property option.
- Enhanced the PageBuilderService to format size values correctly, accommodating both custom and Tailwind class inputs.
- Refactored existing block properties to utilize the new flexible size property for mobile, tablet, and desktop dimensions, improving layout flexibility.